### PR TITLE
fixbug: ansible's drift role failed when drifting container's volume

### DIFF
--- a/playbooks/roles/drift/tasks/main.yaml
+++ b/playbooks/roles/drift/tasks/main.yaml
@@ -7,7 +7,7 @@
   when: node_name == target_node
 
 - name: write rsyncd password file
-  shell: echo "{{ rsync_secrets }}" > /tmp/pass
+  shell: etcdctl get /lain/config/rsyncd_secrets > /tmp/pass
   when: node_name == target_node
 
 - name: chmod password file


### PR DESCRIPTION
drift container 时候 volume 的迁移 ansible 出错，因为 rsyncd 的 secret 已经改成存放到etcd，这里之前忘记修改了。