### PR TITLE
fix collectd exec plugin format

### DIFF
--- a/playbooks/roles/collectd/templates/lain.conf.j2
+++ b/playbooks/roles/collectd/templates/lain.conf.j2
@@ -1,10 +1,10 @@
 TypesDB "/var/lib/collectd/types/lain.db"
 
 <Plugin exec>
-        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/lain_docker.py --domain {{domain}}"
-        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/cluster_monitor.py --swarm-manager-port {{ swarm_manager_port }}"
-        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/lainlet_monitor.py --lainlet-port {{ lainlet_port }}"
-        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/deployd_monitor.py --deployd-port {{ deployd_port }}"
+        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/lain_docker.py" "--domain" "{{domain}}"
+        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/cluster_monitor.py" "--swarm-manager-port" "{{ swarm_manager_port }}"
+        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/lainlet_monitor.py" "--lainlet-port" "{{ lainlet_port }}"
+        Exec "collectd:docker" "/var/lib/collectd/plugins/lain/deployd_monitor.py" "--deployd-port" "{{ deployd_port }}"
 </Plugin>
 
 <Plugin processes>


### PR DESCRIPTION
According to https://collectd.org/wiki/index.php/Plugin:Exec . script args should have their own quotation marks. 