### PR TITLE
drift 时先在目标节点预热镜像，然后再 stop container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ playbooks/roles/binary/files/*
 **/dist
 **/*.egg-info
 venv/
+lainctl/

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ playbooks/roles/binary/files/*
 **/dist
 **/*.egg-info
 venv/
-lainctl/

--- a/playbooks/roles/drift-warm-up/meta/main.yaml
+++ b/playbooks/roles/drift-warm-up/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - libraries

--- a/playbooks/roles/drift-warm-up/tasks/main.yaml
+++ b/playbooks/roles/drift-warm-up/tasks/main.yaml
@@ -1,0 +1,12 @@
+- name: check whether images exist
+  docker_check_images:
+    images: "{{ to_drift_images }}"
+  when: node_name == target_node
+  ignore_errors: yes
+  register: check
+  changed_when: False
+
+- name: pull images when not exist (this may take minutes)
+  docker_pull_image: image={{ item }}
+  with_items: "{{ to_drift_images }}"
+  when: check|failed

--- a/playbooks/roles/drift-warm-up/tasks/main.yaml
+++ b/playbooks/roles/drift-warm-up/tasks/main.yaml
@@ -9,4 +9,4 @@
 - name: pull images when not exist (this may take minutes)
   docker_pull_image: image={{ item }}
   with_items: "{{ to_drift_images }}"
-  when: check|failed
+  when: node_name == target_node and (check|failed)


### PR DESCRIPTION
# 起因

drift 时如果目标节点没有镜像，那么部署的时候需要先拉取镜像，要花费较长的时间，所以容器停止的时间较长，不利于生产环境下的无缝迁移。

# 经过

加了 ansible 脚本，如果目标节点没有镜像的话先拉取镜像，再停止容器，再部署，极大地缩短了服务中断时间。

# 结果（使用 [go-blog-on-lain](https://github.com/kaizhang-shanxi/go-blog-on-lain/tree/with-entrypoint) 测试，没计算 `drift volumes` 的时间）

+ 不预热且目标节点没有镜像时，部署要花 56.67 秒；
+ 预热时，先拉取镜像（41.13 秒），再停止容器，再部署（12 秒）。

相当于服务中断时间缩短了 41.13 秒。

# 备注

+ 在 `.gitignore` 里添加 `lainctl` 是为了调试时方便，将来 `lainctl` 似乎要与 `lain` 合并到一起，我现在也是这么使用的，所以先在 git 里忽略，到时从 `.gitignore` 里移除即可；
+ **重要**：此 pr 与 [https://github.com/laincloud/lainctl/pull/9](https://github.com/laincloud/lainctl/pull/9) 同时发起。