### PR TITLE
stop and rm container first when run container in systemd

### DIFF
--- a/playbooks/roles/rebellion/templates/rebellion.service.j2
+++ b/playbooks/roles/rebellion/templates/rebellion.service.j2
@@ -4,8 +4,10 @@ Requires=docker.service
 After=docker.service
 
 [Service]
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run \
-          --name %n --rm --network=host \
+          --name %n --restart=always --network=host \
           -e LAINLET_PORT={{ lainlet_port }} \
           -v {{ lain_data_dir }}/volumes/:/data/lain/volumes/:ro \
           -v {{ lain_data_dir }}/rebellion/var/lib/filebeat/:/var/lib/filebeat \
@@ -14,7 +16,6 @@ ExecStart=/usr/bin/docker run \
           -v /var/log/:/var/log/syslog/:ro \
           {{ rebellion_image }}
 ExecStop=/bin/bash -c '/usr/bin/docker stop %n || true'
-Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/playbooks/roles/swarm-manage/templates/swarm-agent.service.j2
+++ b/playbooks/roles/swarm-manage/templates/swarm-agent.service.j2
@@ -3,14 +3,15 @@ Description=docker swarm agent
 After=docker.service
 
 [Service]
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run \
           --name %n \
-          --rm \
+          --restart=always \
           {{ swarm_image }} join \
           --addr={{ node_ip }}:{{ docker_port }} \
           etcd://{{ node_ip }}:{{ etcd_client_port }}/lain/swarm
 ExecStop=/bin/bash -c '/usr/bin/docker stop %n || true'
-Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/playbooks/roles/swarm-manage/templates/swarm-manager.service.j2
+++ b/playbooks/roles/swarm-manage/templates/swarm-manager.service.j2
@@ -3,16 +3,17 @@ Description=docker swarm manager
 After=docker.service
 
 [Service]
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run \
           --name %n \
-          --rm \
+          --restart=always \
           -p {{ swarm_manager_port }}:{{ docker_port }} \
           {{ swarm_image }} manage \
           --replication \
           --addr={{ node_ip }}:{{ swarm_manager_port }} \
           etcd://{{ node_ip }}:{{ etcd_client_port }}/lain/swarm
 ExecStop=/bin/bash -c '/usr/bin/docker stop %n || true'
-Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The previous behavior is:
- `systemctl start rebellion` will fail when there is an exited container

The currency behavior is:
- `systemctl start rebellion` always succeed, which equal to `docker stop rebellion.service && docker rm rebellion.service && docker start rebellion.service --${param1} ${value1} ...`
- docker daemon control the restart of the container, instead of systemd, making it more robust