### PR TITLE
fix dnsmasq bug

### DIFF
--- a/playbooks/roles/dnsmasq/tasks/main.yaml
+++ b/playbooks/roles/dnsmasq/tasks/main.yaml
@@ -1,7 +1,7 @@
 - name: install dnsmasq
   package:
     name: dnsmasq
-    state: present
+    state: latest
 
 - name: ensure dnsmasq.hosts
   file: path="{{ dnsmasq_hosts_path }}" state=touch


### PR DESCRIPTION
`bootstrap` failed because dnsmasq 2.6 think empty `/etc/dnsmasq.servers` is wrong, upgrade dnsmasq to 2.7 fix this error.