### PR TITLE
upgrade networkd from v2.3.x to v2.4.0

### DIFF
--- a/playbooks/roles/networkd-preupgrade/tasks/main.yaml
+++ b/playbooks/roles/networkd-preupgrade/tasks/main.yaml
@@ -1,0 +1,50 @@
+# ansible bug: get_url fails to retrieve https url through http proxy, so just use command
+- name: get networkd:v2.4.0
+  command: wget https://lain.oss-cn-beijing.aliyuncs.com/binary/networkd/releases/download/v2.4.0/networkd.xz -O /tmp/networkd.xz
+
+- name: unxz networkd.xz
+  command: unxz -kf /tmp/networkd.xz
+
+- name: set etcd domains from /etc/dnsmasq.conf
+  command: etcdctl set /lain/config/domains/{{ item.split('/')[-2] }} '{"ips":[],"type":"node"}'
+  with_lines: cat /etc/dnsmasq.conf
+  when: item | regex_search('(^address=)') and not item | regex_search('(^address=/lain.local)')
+
+- name: set etcd domain for *.lain.local
+  command: etcdctl set /lain/config/domains/*.lain.local '{"ips":[],"type":"webrouter"}'
+
+- name: load dnshijack keys from etcd
+  command: etcdctl ls /lain/config/dnshijack
+  register: hijack_domain_list
+  ignore_errors: yes
+  changed_when: False
+
+- name : load dnshijack settings from etcd
+  command: etcdctl get {{ item.1 }}
+  register: hijack_ip_list
+  with_indexed_items: "{{ hijack_domain_list.stdout_lines }}"
+  when: hijack_domain_list|success and hijack_domain_list.stdout != ""
+  changed_when: False
+
+- name: set etcd domains from dnshijack
+  command: etcdctl set /lain/config/domains/*.{{ item.1.split('/')[-1] }} '{"ips":["{{ hijack_ip_list.results[item.0].stdout }}"],"type":""}'
+  with_indexed_items: "{{ hijack_domain_list.stdout_lines }}"
+  when: hijack_domain_list|success and hijack_domain_list.stdout != ""
+
+- name: load dnsmasq_addresses keys from etcd
+  command: etcdctl ls /lain/config/dnsmasq_addresses
+  register: dnsmasq_domain_list
+  ignore_errors: yes
+  changed_when: False
+
+- name: load dnsmasq_addresses settings from etcd
+  command: etcdctl get {{ item }}
+  register: dnsmasq_ip_list
+  with_items: " {{ dnsmasq_domain_list.stdout_lines  }} "
+  when: dnsmasq_domain_list|success and dnsmasq_domain_list.stdout != ""
+  changed_when: False
+
+- name: set etcd domains from dnsmasq_addresses
+  command: etcdctl set /lain/config/domains/{{ item.1.split('/')[-1] }} '{{ dnsmasq_ip_list.results[item.0].stdout }}'
+  with_indexed_items: "{{ dnsmasq_domain_list.stdout_lines }}"
+  when: dnsmasq_domain_list|success and dnsmasq_domain_list.stdout != ""

--- a/playbooks/roles/networkd-rollback/tasks/main.yaml
+++ b/playbooks/roles/networkd-rollback/tasks/main.yaml
@@ -1,0 +1,29 @@
+- name: rollback networkd
+  copy: 
+    remote_src: True
+    src: /usr/bin/networkd.back
+    dest: /usr/bin/networkd
+    force: yes
+
+- name: rollback networkd.service
+  copy:
+    remote_src: True
+    src: /etc/systemd/system/networkd.service.back
+    dest: /etc/systemd/system/networkd.service
+    force: yes
+
+- name: systemctl daemon-reload
+  command: systemctl daemon-reload
+
+- name: systemctl restart networkd && systemctl enable networkd
+  service:
+    name: networkd
+    state: restarted
+    enabled: yes
+
+- name: systemctl restart dnsmasq && systemctl enable dnsmasq
+  service:
+    name: dnsmasq
+    state: started
+    enabled: yes
+

--- a/playbooks/roles/networkd-upgrade/meta/main.yaml
+++ b/playbooks/roles/networkd-upgrade/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: config

--- a/playbooks/roles/networkd-upgrade/tasks/main.yaml
+++ b/playbooks/roles/networkd-upgrade/tasks/main.yaml
@@ -1,0 +1,45 @@
+- name: backup original networkd
+  copy:
+    remote_src: True
+    src: /usr/bin/networkd
+    dest: /usr/bin/networkd.back
+    force: yes
+ 
+- name: backup original networkd.service
+  copy:
+    remote_src: True
+    src: /etc/systemd/system/networkd.service
+    dest: /etc/systemd/system/networkd.service.back
+    force: yes
+
+- name: copy networkd binary file
+  copy:
+    src: /tmp/networkd
+    dest: /usr/bin/networkd
+    force: yes
+    mode: a+x
+
+- name: install arping
+  # package name is iputils-arping not arping
+  package: name=iputils-arping state=present
+  when: ansible_distribution=="Ubuntu"
+
+- name: generate networkd.service
+  template:
+    src: networkd.service.j2
+    dest: /etc/systemd/system/networkd.service
+
+- name: systemctl stop dnsmasq && systemctl disable dnsmasq
+  service:
+    name: dnsmasq
+    state: stopped
+    enabled: no
+    
+- name: systemctl daemon-reload
+  command: systemctl daemon-reload
+
+- name: systemctl restart networkd && systemctl enable networkd
+  service:
+    name: networkd
+    state: restarted
+    enabled: yes

--- a/playbooks/roles/networkd-upgrade/templates/networkd.service.j2
+++ b/playbooks/roles/networkd-upgrade/templates/networkd.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=networkd
+After=network.target lainlet.service
+
+[Service]
+Environment=ETCD_AUTHORITY=127.0.0.1:{{ etcd_client_port }}
+LimitNOFILE=65535
+ExecStart=/usr/bin/networkd {% if domain == 'lain.local' and vip == '0.0.0.0' %}--domain=lain.local{% endif %} \
+          --net.interface={{ net_interface }} \
+          --lainlet.endpoint={{ node_ip }}:{{ lainlet_port }} \
+          --etcd.endpoint=http://{{ node_ip }}:{{ etcd_client_port }} \
+          --libnetwork \
+          --tinydns \
+          --swarm \
+          --deployd \
+          --webrouter \
+          --streamrouter \
+          --godns.addr=0.0.0.0:53
+
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
upgrade:
ansible-playbook -i playbooks/cluster -e target=localhost -e
role=networkd-preupgrade playbooks/role.yaml
ansible-playbook -i playbooks/cluster -e role=networkd-upgrade
playbooks/role.yaml

rollback:
ansible-playbook -i playbooks/cluster -e role=networkd-rollback
playbooks/role.yaml